### PR TITLE
fix: Fixed smallest circle enclosing 3 points, fix #76

### DIFF
--- a/decide.py
+++ b/decide.py
@@ -81,10 +81,14 @@ def calculate_triangle_area(point1, point2, point3):
     return abs((point2[0] - point1[0])*(point3[1] - point1[1]) - (point3[0] - point1[0])*(point2[1] - point1[1])) / 2
 
 def circumradius(p1, p2, p3):
-    """    Calculates the radius of the circumcircle of a triangle defined by three points.     """
     a = math.dist(p1, p2)
     b = math.dist(p2, p3)
     c = math.dist(p3, p1)
+    
+    largest_angle = max([calculate_angle(p1,p2,p3), calculate_angle(p2,p3,p1), calculate_angle(p3,p1,p2)])
+    if largest_angle >= math.pi/2:
+        return max([a, b, c])/2
+    """    Calculates the radius of the circumcircle of a triangle defined by three points.     """
     area = math.sqrt((a+b+c)*(b+c-a)*(c+a-b)*(a+b-c))
     if area == 0:
         return max(a,b,c)/2

--- a/unit_tests.py
+++ b/unit_tests.py
@@ -306,6 +306,16 @@ class TestDecide(unittest.TestCase):
         decide.PARAMETERS['RADIUS2'] = 0.1
         self.assertFalse(decide.LIC13())
         
+        
+    def test_LIC13_obtuse_triangle(self):
+        decide.POINTS = [[0, 0], [0, 0], [50, 0], [0, 0], [25, 1]]
+        decide.NUMPOINTS = len(decide.POINTS)
+        decide.PARAMETERS['A_PTS'] = 1
+        decide.PARAMETERS['B_PTS'] = 1
+        decide.PARAMETERS['RADIUS1'] = 0.1
+        decide.PARAMETERS['RADIUS2'] = 26
+        self.assertTrue(decide.LIC13())
+        
     def test_LIC13_only_second_condition_met(self):
         decide.POINTS = [[0, 0], [0, 0], [3, 0], [0, 0], [1, 2]]
         decide.NUMPOINTS = len(decide.POINTS)


### PR DESCRIPTION
fix: Fixed smallest circle enclosing 3 points, fix #76 
Added test of LIC13 with an obtuse triangle that failed with the previous version but pass with the corrected version.